### PR TITLE
Updated coin type

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -218,8 +218,8 @@ public:
         // SOV BIP32 prvkeys start with 'xprv' (SOV defaults)
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x88)(0xAD)(0xE4).convert_to_container<std::vector<unsigned char> >();
 
-        // SOV BIP44 coin type is '5'
-        nExtCoinType = 5;
+        // SOV BIP44 coin type is '243'
+        nExtCoinType = 243;
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 


### PR DESCRIPTION
Moved from Dash's cointype 5 to SOV 243.
https://github.com/satoshilabs/slips/pull/496